### PR TITLE
Update multichain release

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get update \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \
         && cd /tmp \
-        && wget http://www.multichain.com/download/multichain-1.0.4.tar.gz \
-        && tar -xvzf multichain-1.0.4.tar.gz \
-        && cd multichain-1.0.4 \
+        && wget http://www.multichain.com/download/multichain-1.0.6.tar.gz \
+        && tar -xvzf multichain-1.0.6.tar.gz \
+        && cd multichain-1.0.6 \
         && mv multichaind multichain-cli multichain-util /usr/local/bin \
         && cd /tmp \
         && rm -Rf multichain*


### PR DESCRIPTION
The version 1.0.6 is the newest release